### PR TITLE
update trove classifiers to accurately reflect license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
 


### PR DESCRIPTION
the repository clearly has the GPLv3 in it, but the trove classifier claims an MIT license. This may create compliance headaches for people, so it should be updated and a release should be made.